### PR TITLE
[market formspec] Add "description display" optional + cosmetics

### DIFF
--- a/formspecs.lua
+++ b/formspecs.lua
@@ -128,7 +128,7 @@ local inventory_desc_comp = function(invitem1, invitem2) return invitem1.descrip
 
 local get_account_formspec = function(market, account)
 	local show_itemnames = account.show_itemnames == "true"
-	local show_description = account.show_description == "true"
+	local show_descriptions = account.show_descriptions == "true"
 	local show_icons = global_enable_item_icons and ((account.show_icons or "true") == "true")
 	local market_def = market.def
 	
@@ -150,7 +150,7 @@ local get_account_formspec = function(market, account)
 	end
 	if show_itemnames then
 		table.sort(inventory, inventory_item_comp)
-	elseif show_description then
+	elseif show_descriptions then
 		table.sort(inventory, inventory_desc_comp)
 	end
 
@@ -170,7 +170,7 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = "text;"
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = "text;"
 	end
 	formspec[#formspec+1] = "text,align=center"
@@ -183,7 +183,7 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = ";text"
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = ";text"
 	end
 	formspec[#formspec+1] = ";text,align=center]"
@@ -195,7 +195,7 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = S("Item")..","
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = S("Description")..","
 	end
 	formspec[#formspec+1] = S("Quantity")
@@ -205,7 +205,7 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = ","..S("Item")
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = ","..S("Description")
 	end
 	formspec[#formspec+1] = ","..S("Quantity")
@@ -217,7 +217,7 @@ local get_account_formspec = function(market, account)
 		if show_itemnames then
 			formspec[#formspec+1] = "," .. truncate_string(entry.item, truncate_item_names_to)
 		end
-		if show_description then
+		if show_descriptions then
 			-- no need to formspec_escape description here, it gets done when it's initially added to the inventory table
 			formspec[#formspec+1] = "," .. entry.description
 		end
@@ -376,7 +376,7 @@ local get_market_formspec = function(market, account)
 	local selected = account.selected
 	local market_list = make_marketlist(market, account)
 	local show_itemnames = account.show_itemnames == "true"
-	local show_description = account.show_description == "true"
+	local show_descriptions = account.show_descriptions == "true"
 	local show_icons = global_enable_item_icons and ((account.show_icons or "true") == "true")
 	local anonymous = market_def.anonymous
 
@@ -397,7 +397,7 @@ local get_market_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = "text;" -- itemname
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = "text;" -- description
 	end
 	formspec[#formspec+1] = "color,span=2;"
@@ -417,7 +417,7 @@ local get_market_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = "Item," -- itemname
 	end
-	if show_description then
+	if show_descriptions then
 		formspec[#formspec+1] = S("Description") .. ","
 	end
 	formspec[#formspec+1] = "#00FF00,"..S("Buy Vol")..","..S("Buy Max")
@@ -435,7 +435,7 @@ local get_market_formspec = function(market, account)
 		if show_itemnames then
 			formspec[#formspec+1] = "," .. truncate_string(row.item, truncate_item_names_to)
 		end
-		if show_description then
+		if show_descriptions then
 			formspec[#formspec+1] = "," .. get_item_description(row.item)
 		end
 
@@ -625,8 +625,8 @@ local get_info_formspec = function(market, account)
 	formspec[#formspec+1] = "]container[0.5, 7.6]label[0,0;"..S("Settings")..":]checkbox[0,0.25;show_itemnames;"..S("Show Itemnames")..";"
 		..show_itemnames.."]"
 
-	local show_description = account.show_description or "false"
-	formspec[#formspec+1] = "checkbox[2.1,0.25;show_description;"..S("Show Description")..";"..show_description.."]"
+	local show_descriptions = account.show_descriptions or "false"
+	formspec[#formspec+1] = "checkbox[2.1,0.25;show_descriptions;"..S("Show Descriptions")..";"..show_descriptions.."]"
 
 	if global_enable_item_icons then
 		local show_icons = account.show_icons or "true"
@@ -790,14 +790,14 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			-- Find the item that was clicked on
 			local col_count = 8
 			local show_itemnames = account.show_itemnames == "true"
-			local show_description = account.show_description == "true"
+			local show_descriptions = account.show_descriptions == "true"
 			if not show_itemnames then
 				col_count = col_count - 2
 			end
 			if not show_icons then
 				col_count = col_count - 2
 			end
-			if not show_description then
+			if not show_descriptions then
 				col_count = col_count -2
 			end
 			local index = math.floor(((invevent.row-1)*col_count + invevent.column - 1)/(col_count/2)) - 1
@@ -811,7 +811,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 			if show_itemnames then
 				table.sort(inventory, inventory_item_comp)
-			elseif show_description then
+			elseif show_descriptions then
 				table.sort(inventory, inventory_desc_comp)
 			end
 			if inventory[index] then
@@ -870,7 +870,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	if process_checkbox("filter_participating", fields, account) then something_changed = true end
 	if process_checkbox("show_itemnames", fields, account) then something_changed = true end
-	if process_checkbox("show_description", fields, account) then something_changed = true end
+	if process_checkbox("show_descriptions", fields, account) then something_changed = true end
 	if process_checkbox("show_icons", fields, account) then something_changed = true end
 
 	if fields.acknowledge_log then

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -94,32 +94,31 @@ commoditymarket.get_icon = get_icon
 
 
 local truncate_string = function(target, length)
-	if target:len() > length then
-		return target:sub(1,length-2).."..."
+	local strip_target = minetest.strip_colors(target)
+	if strip_target:len() > length then
+		return string.sub(strip_target,1,length-2).."..."
 	end
-	return target
+	return strip_target
 end
 
 local get_translated_string = minetest.get_translated_string
 local lang_code = nil -- it's ugly using this to pass the language code into this function, but it's efficient and works well for the sort functions.
-local get_item_description = function(item)	
+local get_item_description = function(item)
+	local description = S("Unknown Item")
 	local def = minetest.registered_items[item]
+
 	if def then
-		local description = def.description
-		if description then
-			-- added in https://github.com/minetest/minetest/pull/9733
-			-- Eventually this check can be removed, for now gives a little backward compatibility
-			if get_translated_string then
-				description = get_translated_string(lang_code, description)
-			end
-			return minetest.formspec_escape(description:gsub("\n", " "))
+		description = def.description
+		if get_translated_string then
+			description = get_translated_string(lang_code, description)
 		end
 	end
-	if get_translated_string then
-		return get_translated_string(lang_code, S("Unknown Item"))
-	end
-	return S("Unknown Item")
+	
+	-- We keep the first line of the description, which is the game name of an item (ex: "Dirt" for the item "default:dirt")
+	description = description:split("\n", false, 2)[1]
+	return truncate_string(minetest.formspec_escape(description),truncate_item_names_to)
 end
+
 
 -- Inventory formspec
 -------------------------------------------------------------------------------------
@@ -129,6 +128,7 @@ local inventory_desc_comp = function(invitem1, invitem2) return invitem1.descrip
 
 local get_account_formspec = function(market, account)
 	local show_itemnames = account.show_itemnames == "true"
+	local show_description = account.show_description == "true"
 	local show_icons = global_enable_item_icons and ((account.show_icons or "true") == "true")
 	local market_def = market.def
 	
@@ -150,7 +150,7 @@ local get_account_formspec = function(market, account)
 	end
 	if show_itemnames then
 		table.sort(inventory, inventory_item_comp)
-	else
+	elseif show_description then
 		table.sort(inventory, inventory_desc_comp)
 	end
 
@@ -170,7 +170,10 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = "text;"
 	end
-	formspec[#formspec+1] = "text;text,align=center"
+	if show_description then
+		formspec[#formspec+1] = "text;"
+	end
+	formspec[#formspec+1] = "text,align=center"
 	if show_icons then
 		formspec[#formspec+1] = ";image"
 		for i=2, #inventory, 2 do
@@ -180,7 +183,10 @@ local get_account_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = ";text"
 	end
-	formspec[#formspec+1] = ";text;text,align=center]"
+	if show_description then
+		formspec[#formspec+1] = ";text"
+	end
+	formspec[#formspec+1] = ";text,align=center]"
 		.."tooltip[inventory;"..S("All the items you've transferred to the market to sell and the items you've\npurchased with buy orders. Double-click on an item to bring it back into your\npersonal inventory.").."]"
 		.."table[0,0;9.75,4;inventory;"
 	if show_icons then
@@ -188,15 +194,21 @@ local get_account_formspec = function(market, account)
 	end
 	if show_itemnames then
 		formspec[#formspec+1] = S("Item")..","
-	end	
-	formspec[#formspec+1] = S("Description")..","..S("Quantity")
+	end
+	if show_description then
+		formspec[#formspec+1] = S("Description")..","
+	end
+	formspec[#formspec+1] = S("Quantity")
 	if show_icons then
 		formspec[#formspec+1] = ",0"
 	end
 	if show_itemnames then
 		formspec[#formspec+1] = ","..S("Item")
-	end	
-	formspec[#formspec+1] = ","..S("Description")..","..S("Quantity")
+	end
+	if show_description then
+		formspec[#formspec+1] = ","..S("Description")
+	end
+	formspec[#formspec+1] = ","..S("Quantity")
 
 	for i, entry in ipairs(inventory) do
 		if show_icons then
@@ -204,10 +216,13 @@ local get_account_formspec = function(market, account)
 		end
 		if show_itemnames then
 			formspec[#formspec+1] = "," .. truncate_string(entry.item, truncate_item_names_to)
-		end	
-		-- no need to formspec_escape description here, it gets done when it's initially added to the inventory table
-		formspec[#formspec+1] = "," .. entry.description .. "," .. entry.quantity
-	end	
+		end
+		if show_description then
+			-- no need to formspec_escape description here, it gets done when it's initially added to the inventory table
+			formspec[#formspec+1] = "," .. entry.description
+		end
+		formspec[#formspec+1] = "," .. entry.quantity
+	end
 	
 	formspec[#formspec+1] = "]container[0.5,4.5]"
 	
@@ -361,6 +376,7 @@ local get_market_formspec = function(market, account)
 	local selected = account.selected
 	local market_list = make_marketlist(market, account)
 	local show_itemnames = account.show_itemnames == "true"
+	local show_description = account.show_description == "true"
 	local show_icons = global_enable_item_icons and ((account.show_icons or "true") == "true")
 	local anonymous = market_def.anonymous
 
@@ -377,11 +393,14 @@ local get_market_formspec = function(market, account)
 			formspec[#formspec+1] = "," .. i .. "=" .. get_icon(row.item)
 		end
 		formspec[#formspec+1] = ";"
-	end	if show_itemnames then
+	end
+	if show_itemnames then
 		formspec[#formspec+1] = "text;" -- itemname
 	end
-	formspec[#formspec+1] = "text;" -- description
-		.."color,span=2;"
+	if show_description then
+		formspec[#formspec+1] = "text;" -- description
+	end
+	formspec[#formspec+1] = "color,span=2;"
 		.."text,align=right,tooltip="..S("Number of items there's demand for in the market.")..";"
 		.."text,align=right,tooltip="..S("Maximum price being offered to buy one of these.")..";"
 		.."color,span=2;"
@@ -398,7 +417,10 @@ local get_market_formspec = function(market, account)
 	if show_itemnames then
 		formspec[#formspec+1] = "Item," -- itemname
 	end
-	formspec[#formspec+1] = S("Description")..",#00FF00,"..S("Buy Vol")..","..S("Buy Max")
+	if show_description then
+		formspec[#formspec+1] = S("Description") .. ","
+	end
+	formspec[#formspec+1] = "#00FF00,"..S("Buy Vol")..","..S("Buy Max")
 		..",#FF0000,"..S("Sell Vol")..","..S("Sell Min")..","..S("Last Price")..","..S("Inventory")
 
 	local selected_idx
@@ -413,9 +435,11 @@ local get_market_formspec = function(market, account)
 		if show_itemnames then
 			formspec[#formspec+1] = "," .. truncate_string(row.item, truncate_item_names_to)
 		end
+		if show_description then
+			formspec[#formspec+1] = "," .. get_item_description(row.item)
+		end
 
-		formspec[#formspec+1] = "," .. get_item_description(row.item)
-		.. ",#00FF00,"
+		formspec[#formspec+1] = ",#00FF00,"
 		.. row.buy_volume
 		.. "," .. ((row.buy_orders[#row.buy_orders] or {}).price or "-")
 		.. ",#FF0000,"
@@ -453,14 +477,7 @@ local get_market_formspec = function(market, account)
 	if selected_row then
 		local current_time = minetest.get_gametime()
 
-		local desc_display
-		if show_itemnames then
-			desc_display = selected
-		else
-			local def = minetest.registered_items[selected_row.item] or {description=S("Unknown Item")}
-			desc_display = minetest.formspec_escape(def.description:gsub("\n", " "))
-		end
-
+		local desc_display = get_item_description(selected)
 		-- player inventory for this item and for currency
 		formspec[#formspec+1] = "label[0.1,5.1;"..desc_display.."\n"..S("In inventory:").." "
 			.. tostring(account.inventory[selected] or 0) .."\n"..S("Balance:").." "..market_def.currency_symbol..account.balance .."]"
@@ -602,14 +619,19 @@ local get_info_formspec = function(market, account)
 	else
 		formspec[#formspec+1] = "#CCCCCC"..S("No logged activities in this market yet.").."]"
 	end
-	local show_itemnames = account.show_itemnames or "false"
 
+	local show_itemnames = account.show_itemnames or "false"
+	
 	formspec[#formspec+1] = "]container[0.5, 7.6]label[0,0;"..S("Settings")..":]checkbox[0,0.25;show_itemnames;"..S("Show Itemnames")..";"
 		..show_itemnames.."]"
+
+	local show_description = account.show_description or "false"
+	formspec[#formspec+1] = "checkbox[2.1,0.25;show_description;"..S("Show Description")..";"..show_description.."]"
+
 	if global_enable_item_icons then
-		local show_icons = account.show_icons or "true"	
-		formspec[#formspec+1] = "checkbox[2,0.25;show_icons;"..S("Show Icons")..";"..show_icons.."]"
-	end		
+		local show_icons = account.show_icons or "true"
+		formspec[#formspec+1] = "checkbox[4.2,0.25;show_icons;"..S("Show Icons")..";"..show_icons.."]"
+	end	
 	formspec[#formspec+1] = "container_end[]"
 
 	return table.concat(formspec)
@@ -768,11 +790,15 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			-- Find the item that was clicked on
 			local col_count = 8
 			local show_itemnames = account.show_itemnames == "true"
+			local show_description = account.show_description == "true"
 			if not show_itemnames then
 				col_count = col_count - 2
 			end
 			if not show_icons then
 				col_count = col_count - 2
+			end
+			if not show_description then
+				col_count = col_count -2
 			end
 			local index = math.floor(((invevent.row-1)*col_count + invevent.column - 1)/(col_count/2)) - 1
 			local account = market:get_account(name)
@@ -785,7 +811,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 			if show_itemnames then
 				table.sort(inventory, inventory_item_comp)
-			else
+			elseif show_description then
 				table.sort(inventory, inventory_desc_comp)
 			end
 			if inventory[index] then
@@ -844,6 +870,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	if process_checkbox("filter_participating", fields, account) then something_changed = true end
 	if process_checkbox("show_itemnames", fields, account) then something_changed = true end
+	if process_checkbox("show_description", fields, account) then something_changed = true end
 	if process_checkbox("show_icons", fields, account) then something_changed = true end
 
 	if fields.acknowledge_log then

--- a/locale/commoditymarket.de.tr
+++ b/locale/commoditymarket.de.tr
@@ -80,7 +80,7 @@ Sell Min=Minverkauf
 Sell Vol=Verkaufsvol
 Sell limit:=Verkaufsgrenze:
 Show Icons=Symbole anzeigen
-Show Description=
+Show Descriptions=
 Show Itemnames=Gegenstandsnamen
 Settings=
 

--- a/locale/commoditymarket.de.tr
+++ b/locale/commoditymarket.de.tr
@@ -80,6 +80,7 @@ Sell Min=Minverkauf
 Sell Vol=Verkaufsvol
 Sell limit:=Verkaufsgrenze:
 Show Icons=Symbole anzeigen
+Show Description=
 Show Itemnames=Gegenstandsnamen
 Settings=
 

--- a/locale/commoditymarket.es.tr
+++ b/locale/commoditymarket.es.tr
@@ -107,6 +107,7 @@ Sell Vol=Volumen de venta.
 Sell limit:=Limite de venta.
 #checkbox label
 Show Icons=Mostrar iconos
+Show Description=
 #checkbox label
 Show Itemnames=Mostrar nombres de artículos
 Settings=

--- a/locale/commoditymarket.es.tr
+++ b/locale/commoditymarket.es.tr
@@ -107,7 +107,7 @@ Sell Vol=Volumen de venta.
 Sell limit:=Limite de venta.
 #checkbox label
 Show Icons=Mostrar iconos
-Show Description=
+Show Descriptions=
 #checkbox label
 Show Itemnames=Mostrar nombres de artículos
 Settings=

--- a/locale/commoditymarket.fr.tr
+++ b/locale/commoditymarket.fr.tr
@@ -98,7 +98,7 @@ Sell limit:=Limite de vente:
 #checkbox label
 Show Icons=Montrer les icônes
 Show Itemnames=Montrer les noms
-Show Description=Montrer les labels
+Show Descriptions=Montrer les labels
 Settings=Paramètres
 
 The name of the player who placed this order.@nDouble-click your own orders to cancel them.=Nom du joueur ayant placé l'offre.@nDouble-cliquer sur votre offres pour l'annuler

--- a/locale/commoditymarket.pt.tr
+++ b/locale/commoditymarket.pt.tr
@@ -108,7 +108,7 @@ Sell Vol=V. Vol
 Sell limit:=Venda limite:
 #checkbox label
 Show Icons=Ver icones
-Show Description=
+Show Descriptions=
 #checkbox label
 Show Itemnames=Ver itens
 Settings=

--- a/locale/commoditymarket.pt.tr
+++ b/locale/commoditymarket.pt.tr
@@ -108,6 +108,7 @@ Sell Vol=V. Vol
 Sell limit:=Venda limite:
 #checkbox label
 Show Icons=Ver icones
+Show Description=
 #checkbox label
 Show Itemnames=Ver itens
 Settings=

--- a/locale/commoditymarket.pt_BR.tr
+++ b/locale/commoditymarket.pt_BR.tr
@@ -108,7 +108,7 @@ Sell Vol=V. Vol
 Sell limit:=Venda limite:
 #checkbox label
 Show Icons=Ver icones
-Show Description=
+Show Descriptions=
 #checkbox label
 Show Itemnames=Ver itens
 Settings=

--- a/locale/commoditymarket.pt_BR.tr
+++ b/locale/commoditymarket.pt_BR.tr
@@ -108,6 +108,7 @@ Sell Vol=V. Vol
 Sell limit:=Venda limite:
 #checkbox label
 Show Icons=Ver icones
+Show Description=
 #checkbox label
 Show Itemnames=Ver itens
 Settings=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -108,7 +108,7 @@ Sell Vol=
 Sell limit:=
 #checkbox label
 Show Icons=
-Show Description=
+Show Descriptions=
 #checkbox label
 Show Itemnames=
 Settings=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -108,6 +108,7 @@ Sell Vol=
 Sell limit:=
 #checkbox label
 Show Icons=
+Show Description=
 #checkbox label
 Show Itemnames=
 Settings=


### PR DESCRIPTION
## What changed
* Add a checkbox to display/hide description
* Truncate the description if more than 30 characters, as for item name
* Display first line of the description instead all of it, to get the display name (Ex: "Dirt" instead of "default:dirt"). This replicates the behavior for the mod with default game.
* Display interface name of selected item below the table, instead of either full description or registered name

### Explanation of why we need to change description to use.
I did my tests in Mineclone2. There is no issue with default game, here's why.
Description of a mineclone2 item looks like 
```
item name
detailled description
```
whereas in default game, description is only `item name`

I think we can keep only the first line, which seems to make sense to me.


> I tested changes both in default game and Minclone2 

## Before
![Capture d’écran du 2024-01-13 22-24-53](https://github.com/minetest-mods/commoditymarket/assets/14837771/7f932e08-1ef0-4e93-b13a-4fba2bb82f66)
![Capture d’écran du 2024-01-13 22-24-46](https://github.com/minetest-mods/commoditymarket/assets/14837771/0de7086a-adf4-4bcd-8be6-f84ddc80e0bf)
![Capture d’écran du 2024-01-13 22-24-41](https://github.com/minetest-mods/commoditymarket/assets/14837771/93bbc810-d649-4d4b-b98d-3ffbc27fff82)
![Capture d’écran du 2024-01-13 22-24-35](https://github.com/minetest-mods/commoditymarket/assets/14837771/31aaa764-1b1e-435f-bc78-92331d481515)

## After
![Capture d’écran du 2024-01-13 22-26-43](https://github.com/minetest-mods/commoditymarket/assets/14837771/0cc7dbb3-4b71-491c-8f6f-3b4609f3939e)
![Capture d’écran du 2024-01-13 22-26-52](https://github.com/minetest-mods/commoditymarket/assets/14837771/adef2405-28f9-4171-bc6a-1faa819c2c0a)
![Capture d’écran du 2024-01-13 22-26-46](https://github.com/minetest-mods/commoditymarket/assets/14837771/9be425d2-035d-4253-892d-da45bb02b4ad)
![Capture d’écran du 2024-01-13 22-25-16](https://github.com/minetest-mods/commoditymarket/assets/14837771/607e7f5e-76f5-4ec9-995f-c0788de7555d)
![Capture d’écran du 2024-01-14 10-28-26](https://github.com/minetest-mods/commoditymarket/assets/14837771/6504e4d2-5ff9-4db6-b9b8-59e7f823345f)
![Capture d’écran du 2024-01-14 10-46-38](https://github.com/minetest-mods/commoditymarket/assets/14837771/fda13ee3-6f04-4f13-8131-000147012c76)


----
Next step (other MR)
I will try to expand the formspec in width. You can see in the picture that the display is cropped when description is displayed
